### PR TITLE
finagle: bump netty version to 4.1.121

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val releaseVersion = "24.8.0-SNAPSHOT"
 
 val libthriftVersion = "0.10.0"
 
-val defaultNetty4Version = "4.1.100.Final"
+val defaultNetty4Version = "4.1.121.Final"
 val defaultNetty4StaticSslVersion = "2.0.61.Final"
 
 val useNettySnapshot: Boolean = sys.env.get("FINAGLE_USE_NETTY_4_SNAPSHOT") match {


### PR DESCRIPTION
Problem

Netty is out of date

Solution

Upgrade it to 4.1.121


